### PR TITLE
revert to old publishing scheme temporarily

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,17 +4,26 @@ on:
     branches:
     - master
 jobs:
-  release:
-    name: Packages
+  publish:
+    name: "Packages"
     if: github.repository == 'DuncanUszkay1/assemblyscript'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
       with:
-        ref: master
+        ref: release
     - uses: dcodeIO/setup-node-nvm@master
       with:
         node-version: current
+    - name: Merge master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        git config user.name "GitHub Actions"
+        git config user.email "actions@github.com"
+        git remote set-url origin "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+        git fetch origin
+        git merge origin/master
     - name: Install dependencies
       run: npm ci
     - name: Build distribution files
@@ -23,8 +32,41 @@ jobs:
         npm run build
     - name: Test distribution files
       run: npm test
-    - name: Make semantic release
+    - name: Set up version
+      run: |
+        VERSION=$(node -e "console.log(require('./package.json').version)")
+        git add --force dist/*
+        if git rev-parse v$VERSION >/dev/null 2>&1; then
+          VERSION=$VERSION-nightly.$(date "+%Y%m%d")
+          if git rev-parse v$VERSION >/dev/null 2>&1; then
+            echo "Nightly $VERSION does already exist."
+            exit 1
+          fi
+          echo ::set-env name=CHANNEL::nightly
+          echo "Committing nightly ($VERSION) ..."
+          git commit -m "Nightly v$VERSION"
+          npm version $VERSION --no-git-tag-version --force
+        else
+          echo ::set-env name=CHANNEL::latest
+          echo "Committing release ($VERSION) ..."
+          git commit --allow-empty -m "Release v$VERSION"
+        fi
+        echo ::set-env name=VERSION::$VERSION
+        cd lib/loader
+        npm version $VERSION --no-git-tag-version --force
+        cd ../..
+    - name: Create tag and push distribution files
+      run: |
+        git tag v$VERSION
+        git push origin release
+        git push origin v$VERSION
+    - name: Publish to npm
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      run: node node_modules/semantic-release/bin/semantic-release.js --unstable
+        NPM_REGISTRY: "registry.npmjs.org"
+        NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: |
+        npm config set "//${NPM_REGISTRY}/:_authToken=${NPM_AUTH_TOKEN}"
+        npm publish --tag $CHANNEL
+        cd lib/loader
+        npm publish --tag $CHANNEL --access public
+        cd ../..


### PR DESCRIPTION
Seems that semantic versioning isn't quite working. Going to revert that for this repo, and we can change it back before merging