### PR TITLE
Matched fork dependencies with current AS main branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "assemblyscript-closures-beta",
-  "version": "0.0.0",
+  "version": "0.10.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,26 @@
   },
   "dependencies": {
     "binaryen": "93.0.0-nightly.20200609",
-    "long": "^4.0.0"
+    "long": "^4.0.0",
+    "source-map-support": "^0.5.19",
+    "ts-node": "^6.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^14.0.13",
+    "@typescript-eslint/eslint-plugin": "^3.2.0",
+    "@typescript-eslint/parser": "^3.2.0",
+    "browser-process-hrtime": "^1.0.0",
+    "diff": "^4.0.2",
+    "eslint": "^7.2.0",
+    "glob": "^7.1.6",
+    "physical-cpu-count": "^2.0.0",
+    "semantic-release": "github:dcodeIO/semantic-release",
+    "source-map-support": "^0.5.19",
+    "ts-loader": "^7.0.5",
+    "ts-node": "^6.2.0",
+    "typescript": "^3.9.5",
+    "webpack": "^4.43.0",
+    "webpack-cli": "^3.3.11"
   },
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
So I noticed that CI is failing because it seems like we are missing some dependencies? 

E.g from the PR: https://github.com/DuncanUszkay1/assemblyscript/pull/11

The CI fails here: https://github.com/DuncanUszkay1/assemblyscript/pull/11/checks?check_run_id=828475553

Because when it tries to run a script in `scripts/` it's missing a dev dependency. So I went ahead and matched up our current dependencies with the current AS, that way we can hopefully get accurate CI when we need to merge back to AS (and for making tests pass for closures) :smile: 

cc @DuncanUszkay1 